### PR TITLE
Fix Xcode Cloud build: Remove unused App Groups entitlement

### DIFF
--- a/Config/WordCraft.entitlements
+++ b/Config/WordCraft.entitlements
@@ -12,11 +12,5 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
-	
-	<!-- App group for sharing data between extensions (future-proofing) -->
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.wordcraft.app</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

Xcode Cloud build #22 failed during export with:
- `Automatic signing cannot update bundle identifier "com.wordcraft.app"`
- `No profiles for 'com.wordcraft.app' were found`

## Root Cause

The App Groups entitlement (`group.com.wordcraft.app`) was added for "future-proofing" but is not actually used anywhere in the codebase. This entitlement requires additional configuration on Apple Developer Portal that Xcode Cloud's automatic signing cannot perform.

## Solution

Remove the unused App Groups entitlement from `Config/WordCraft.entitlements`. This simplifies the provisioning requirements to just iCloud/CloudKit, which is the only capability actually used by the app.

## Testing

- Build should succeed in Xcode Cloud after merge
- App functionality unchanged (App Groups was never used)