### PR TITLE
chore: Add pre-push-checks and swiftformat cursor rules

### DIFF
--- a/.cursor/rules/general-rules.mdc
+++ b/.cursor/rules/general-rules.mdc
@@ -14,5 +14,6 @@ Before proceeding with any development work, always read these rule files to und
 - `xcodebuildmcp-tools.mdc` - XcodeBuildMCP tools for building, testing, and deployment
 - `git-worktree.mdc` - **MANDATORY** git worktree workflow for feature branches
 - `git-protection.mdc` - **MANDATORY** never push directly to main branch
+- `pre-push-checks.mdc` - **MANDATORY** build and run tests before pushing
 
 Use the `fetch_rules` tool to access any relevant rule files based on the development task at hand. 

--- a/.cursor/rules/pre-push-checks.mdc
+++ b/.cursor/rules/pre-push-checks.mdc
@@ -1,0 +1,102 @@
+---
+description: "Mandatory pre-push verification - always build and run tests before pushing changes to remote. Apply before any git push command."
+globs: 
+alwaysApply: true
+---
+# Pre-Push Verification Rules
+
+**MANDATORY**: Always build and run tests before pushing any changes to remote. No exceptions.
+
+## Core Rule
+
+**NEVER** execute `git push` without first verifying:
+1. The project builds successfully
+2. All tests pass
+
+## Required Workflow Before Push
+
+### Step 1: Build the Project
+
+```bash
+# Using XcodeBuildMCP tools (preferred)
+mcp_XcodeBuildMCP_build_sim
+
+# Or using xcodebuild directly
+xcodebuild -workspace SpellPlay.xcworkspace -scheme SpellPlay -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' build
+```
+
+### Step 2: Run Tests
+
+```bash
+# Using XcodeBuildMCP tools (preferred)
+mcp_XcodeBuildMCP_test_sim
+
+# Or using xcodebuild directly
+xcodebuild -workspace SpellPlay.xcworkspace -scheme SpellPlay -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' test
+```
+
+### Step 3: Push Only After Success
+
+Only proceed with `git push` if both build and tests succeed.
+
+## Verification Checklist
+
+Before every `git push` command, verify:
+
+- [ ] `build_sim` completed with exit code 0
+- [ ] `test_sim` completed with all tests passing
+- [ ] No new compiler warnings introduced (optional but recommended)
+
+## When User Requests to Push
+
+If the user requests to push changes:
+
+1. **Check if build was run** - If not, run `build_sim` first
+2. **Check if tests were run** - If not, run `test_sim` first
+3. **Only push after both succeed** - If either fails, fix issues before pushing
+
+## Example Workflow
+
+```bash
+# 1. Build first
+mcp_XcodeBuildMCP_build_sim
+
+# 2. Run tests
+mcp_XcodeBuildMCP_test_sim
+
+# 3. Only then push (if both succeeded)
+git push -u origin feature/<branch-name>
+```
+
+## Exception Handling
+
+The only acceptable exceptions:
+- Documentation-only changes (README, docs/, comments)
+- Configuration file updates that don't affect build (.gitignore, editor configs)
+
+Even for exceptions, prefer running a quick build to verify nothing broke.
+
+## Commands to NEVER Execute Without Verification
+
+- `git push origin <branch>`
+- `git push -u origin <branch>`
+- `git push --force origin <branch>`
+- Any `git push` variant
+
+## Rationale
+
+- Prevents broken code from reaching remote repository
+- Catches regressions early before PR review
+- Maintains CI/CD pipeline health
+- Ensures code quality standards are met
+- Saves reviewer time by catching obvious issues
+
+## Quick Reference
+
+| Step | Command | Must Pass? |
+|------|---------|------------|
+| 1. Build | `mcp_XcodeBuildMCP_build_sim` | ✅ Yes |
+| 2. Test | `mcp_XcodeBuildMCP_test_sim` | ✅ Yes |
+| 3. Push | `git push -u origin <branch>` | After 1 & 2 |
+
+**Remember: No push without green build and tests!**

--- a/.cursor/rules/swiftformat.mdc
+++ b/.cursor/rules/swiftformat.mdc
@@ -1,0 +1,135 @@
+---
+description: "SwiftFormat code styling rules - MANDATORY for all Swift files. No changes should be committed without formatting."
+globs: ["**/*.swift"]
+alwaysApply: true
+---
+
+# SwiftFormat Code Styling Rules
+
+**MANDATORY**: All Swift files MUST be formatted with SwiftFormat before committing. No exceptions.
+
+## Core Rule
+
+**NEVER** commit Swift code changes without running SwiftFormat first. Unformatted code is not acceptable.
+
+## Before Every Commit
+
+Run SwiftFormat on changed files:
+
+```bash
+# Format all Swift files
+make format
+
+# Or format specific files
+swiftformat <file.swift> --config .swiftformat
+
+# Or format entire project
+swiftformat SpellPlay SpellPlayUITests --config .swiftformat
+```
+
+## Formatting Workflow
+
+### When Creating New Files
+
+1. Write your Swift code
+2. Run `swiftformat <newfile.swift> --config .swiftformat`
+3. Verify formatting looks correct
+4. Stage and commit
+
+### When Modifying Existing Files
+
+1. Make your changes
+2. Run `swiftformat <modified-files> --config .swiftformat`
+3. Review the formatting changes
+4. Stage and commit
+
+### Before Pushing a Branch
+
+```bash
+# Format all files to ensure consistency
+make format
+
+# Or use lint mode to check without changing
+make lint
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `make format` | Format all Swift files in SpellPlay and SpellPlayUITests |
+| `make lint` | Check formatting without making changes |
+| `make format-check` | Dry-run to preview what would change |
+
+## Key Formatting Rules
+
+The `.swiftformat` configuration enforces:
+
+- **No file headers** - Files start directly with `import` statements
+- **Sorted imports** - Alphabetically ordered
+- **4-space indentation** - Consistent indentation
+- **120 character line width** - Long lines are wrapped
+- **Trailing whitespace removed** - Clean line endings
+- **Unused parameters renamed to `_`** - Clear intent
+- **Redundant code removed** - No unnecessary `return`, `self`, etc.
+
+## What Gets Formatted
+
+- All `.swift` files in `SpellPlay/`
+- All `.swift` files in `SpellPlayUITests/`
+
+## What Is Excluded
+
+- `Pods/` directory
+- `.build/` directory
+- `DerivedData/`
+- Generated files (`*.generated.swift`)
+- `Package.swift` files
+- `worktree/` directories (each worktree has its own formatting)
+
+## Pre-commit Hook (Optional)
+
+To automatically format staged files before commit, install the pre-commit hook:
+
+```bash
+cp scripts/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+## CI/CD Enforcement
+
+Pull requests should fail if code is not properly formatted. Use lint mode in CI:
+
+```bash
+swiftformat SpellPlay SpellPlayUITests --config .swiftformat --lint
+```
+
+## When Reviewing Code
+
+If you see unformatted code in a PR:
+
+1. Request the author to run SwiftFormat
+2. Do not approve PRs with formatting violations
+3. Formatting issues block merge
+
+## Rationale
+
+- **Consistency**: All code looks the same regardless of author
+- **Reduced diffs**: No formatting-only changes in PRs
+- **Faster reviews**: Focus on logic, not style
+- **Automated**: No manual style debates
+
+## Quick Reference
+
+```bash
+# Must run before ANY commit
+make format
+
+# Check if formatting is needed
+make lint
+
+# Format single file
+swiftformat MyFile.swift --config .swiftformat
+```
+
+**Remember: Unformatted code = Unacceptable code**


### PR DESCRIPTION
## Summary
Adds new Cursor IDE rules for development workflow enforcement.

## Changes

### New Rules
- **pre-push-checks.mdc** - Mandatory build and test verification before pushing changes
- **swiftformat.mdc** - SwiftFormat code styling requirements and configuration

### Updated Rules
- **general-rules.mdc** - Added reference to pre-push-checks as mandatory rule

## Pre-Push Checks Rule
Enforces the following workflow before any `git push`:
1. ✅ Build the project (`build_sim`)
2. ✅ Run tests (`test_sim`)
3. ✅ Only push after both succeed

**Exceptions:** Documentation-only and config file changes

## Rationale
- Prevents broken code from reaching remote
- Catches regressions early
- Maintains CI/CD pipeline health