### PR TITLE
ISSUE-013: Model Context Access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,6 +768,10 @@ struct TaskListView: View {
 }
 ```
 
+### ModelContext access
+
+Views own `ModelContext` via `@Environment(\.modelContext)` and pass it into services that need it (e.g. `AchievementService`, `StreakService`). Services receive context in their initializer; the only documented exception is `PracticeSessionState`, which receives context in `setup(test:modelContext:)` and creates services there. See **docs/ARCHITECTURE.md** (ModelContext Access) for the full pattern, call sites, and testing (in-memory `ModelContainer` for tests).
+
 **Important:** Never use CoreData for new projects. SwiftData provides a modern, type-safe API that's easier to work with and integrates seamlessly with SwiftUI.
 
 ---

--- a/SpellPlayTests/ModelContextAccessTests.swift
+++ b/SpellPlayTests/ModelContextAccessTests.swift
@@ -1,0 +1,23 @@
+import SpellPlay
+import SwiftData
+import Testing
+
+@MainActor
+struct ModelContextAccessTests {
+    /// Validates that tests can create an in-memory ModelContainer and pass the resulting
+    /// ModelContext to a service (AchievementService). Ensures no crash and that the
+    /// service can perform a simple operation (getUserProgress).
+    @Test
+    func inMemoryContainer_canInjectForTests() throws {
+        let schema = Schema(CurrentSchema.models)
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let modelContext = container.mainContext
+
+        let service = AchievementService(modelContext: modelContext)
+        let progress = service.getUserProgress()
+
+        #expect(progress.totalPoints == 0)
+        #expect(progress.level == 1)
+    }
+}

--- a/SpellPlayTests/ModelContextAccessTests.swift
+++ b/SpellPlayTests/ModelContextAccessTests.swift
@@ -1,4 +1,4 @@
-import SpellPlay
+@testable import WordCraft
 import SwiftData
 import Testing
 

--- a/docs/ARCHITECTURAL_REVIEW.md
+++ b/docs/ARCHITECTURAL_REVIEW.md
@@ -277,13 +277,15 @@ struct LevelService {
 
 ---
 
-### 13. **ModelContext Access Pattern**
+### 13. **ModelContext Access Pattern** ✅ Documented
 
 **Issue:** Services require `ModelContext` passed in constructor
 
-**Optimization:**
-- Consider using `@Environment(\.modelContext)` in services via dependency injection
-- Or create a `DataService` protocol for consistent access
+**Resolution (ISSUE_013 / #26):** Pattern is documented in **docs/ARCHITECTURE.md** (ModelContext Access):
+- Views own `ModelContext` via `@Environment(\.modelContext)` and pass it into services.
+- Services (`AchievementService`, `StreakService`) receive context in initializer; call sites are StatsView, ChildHomeView, StatsCardView, and PracticeSessionState.setup.
+- **Exception:** PracticeSessionState holds context and creates services in `setup(test:modelContext:)`; documented as allowed exception.
+- Tests use in-memory `ModelContainer` and pass resulting context to services.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,43 @@
+# SpellPlay Architecture
+
+This document captures key architecture decisions and patterns for the SpellPlay iOS app.
+
+## ModelContext Access
+
+**Decision:** Views own `ModelContext` and pass it into services that need it. Services that perform SwiftData operations receive context via initializer (current implementation) or via method parameters (preferred for new code). `ModelContext` is main-actor only; tests use an in-memory `ModelContainer` and pass the resulting context.
+
+### Standard Pattern
+
+1. **Views** obtain `ModelContext` from the environment:
+   ```swift
+   @Environment(\.modelContext) private var modelContext
+   ```
+2. **Call sites** pass `modelContext` when creating or calling services that need persistence:
+   - **StatsView, ChildHomeView, StatsCardView:** Create `AchievementService(modelContext:)` or `StreakService(modelContext:)` with `@Environment(\.modelContext)` and use them in that view.
+   - **PracticeSessionState (exception):** Receives `modelContext` in `setup(test:modelContext:)` and creates `AchievementService` and `StreakService` with that context. The session state holds the context and services for the lifetime of the practice session.
+
+### Current Conforming Types
+
+| Type                  | How it receives context | Call sites |
+|-----------------------|-------------------------|------------|
+| AchievementService    | `init(modelContext:)`   | StatsView, StatsCardView, PracticeSessionState.setup |
+| StreakService        | `init(modelContext:)`   | ChildHomeView, StatsView, PracticeSessionState.setup |
+| PracticeSessionState | `setup(test:modelContext:)` | PracticeView (passes `@Environment(\.modelContext)` into `setup`) |
+
+### Exception: PracticeSessionState
+
+**PracticeSessionState** is the allowed exception: it stores `modelContext` and creates `AchievementService` and `StreakService` in `setup(test:modelContext:)`. The view (`PracticeView`) does not hold the context; it passes it once at session start. This keeps the practice flow simple while still having a single place where context enters the session. Future refactors may move to “view passes context into each service method” and remove stored context from `PracticeSessionState`; see coordination with issue #22 (Remove Practice View Model).
+
+### Testing
+
+- **Unit tests** that need persistence must create an in-memory `ModelContainer` (same schema as the app), obtain a `ModelContext` from it, and pass that context into service initializers or methods.
+- **Main-actor isolation:** `ModelContext` is main-actor only; tests that use it should run on the main actor (e.g. `@MainActor` or `@Test` with main-actor context).
+- No production code should assume a process-wide or environment-injected `ModelContext`; the explicit pass-from-view (or from session setup) pattern keeps dependencies clear and testable.
+
+### Alternatives Considered
+
+- **A – View passes context:** Views get `@Environment(\.modelContext)` and pass to service methods. Services are stateless or do not hold context. *(Recommended for new code.)*
+- **B – Service holds context:** Services created with context in the view (e.g. `@State` or factory). Current pattern for `AchievementService` and `StreakService`.
+- **C – Protocol + injection:** A `ModelContextProviding` or `DataService` protocol with dependency injection for testing. Use when stronger testability or swapping implementations is required.
+
+The project standard is **A** where practical; existing services use **B** and are documented here. **PracticeSessionState** is documented as the exception that holds context and creates services in `setup`.

--- a/docs/issues/ISSUE_VALIDATION_013.md
+++ b/docs/issues/ISSUE_VALIDATION_013.md
@@ -1,0 +1,33 @@
+# ISSUE_013 – Model Context Access – Validation
+
+**GitHub:** [#26](https://github.com/cSquirrel/SpellPlay/issues/26)  
+**Branch:** feature/issue-013-model-context-access
+
+## Acceptance criteria mapping
+
+| Criterion | Validation |
+|-----------|------------|
+| Chosen ModelContext access pattern is documented, including exception (e.g. PracticeSessionState) | **docs/ARCHITECTURE.md** – section "ModelContext Access" documents pattern, call sites, and PracticeSessionState as exception |
+| One documented pattern and list of conforming call sites (or documented exceptions) | ARCHITECTURE.md lists AchievementService, StreakService, PracticeSessionState and call sites |
+| Views (or app root) clearly own and pass ModelContext where needed; ModelContext main-actor only | Documented in ARCHITECTURE.md; views use @Environment(\.modelContext) and pass into services |
+| Tests can inject or mock context (e.g. in-memory ModelContainer) | Unit test `inMemoryContainer_canInjectForTests` in SpellPlayTests validates in-memory container + context passed to service |
+| No new Swift 6 / Sendable / concurrency warnings from context passing changes | Build with strict concurrency; documentation-only + optional test – no service refactor in this PR |
+| Build and tests pass; data persistence behavior unchanged | QA: run build and full test suite; manual smoke (create test, practice, complete; achievements/streaks) |
+
+## Required unit tests (Swift Testing)
+
+| Test | Validates | Location |
+|------|-----------|----------|
+| `inMemoryContainer_canInjectForTests` | In-memory ModelContainer and context passed to service; no crash | SpellPlayTests/ModelContextAccessTests.swift |
+| `serviceReceivesContext_fromCaller` | Optional: service method receives context and succeeds with in-memory context | Same file if refactor done |
+
+**Note:** SpellPlayTests target builds with the project. To run unit tests: in Xcode select the SpellPlayTests target and run tests (⌘U), or run the SpellPlayTests bundle from command line. The SpellPlay scheme’s test action uses a test plan that currently references SpellPlayUITests only.
+
+## QA checklist
+
+- [ ] Build succeeds (simulator).
+- [ ] All unit tests pass (SpellPlayTests).
+- [ ] All UI tests pass (SpellPlayUITests) if run.
+- [ ] docs/ARCHITECTURE.md is clear and matches code (views pass context; PracticeSessionState exception).
+- [ ] No new concurrency/Sendable warnings.
+- [ ] Manual: create test, run practice, complete session; confirm data saved and achievements/streaks update if applicable.


### PR DESCRIPTION
## Summary
Documents and standardizes how services receive `ModelContext` (views own it via `@Environment(\.modelContext)` and pass it in; services receive via initializer). `PracticeSessionState` is documented as the allowed exception.

## Changes
- **docs/ARCHITECTURE.md** (new): ModelContext Access section — standard pattern, current conforming types and call sites, exception (PracticeSessionState), testing (in-memory container).
- **docs/ARCHITECTURAL_REVIEW.md**: §13 updated with resolution and pointer to ARCHITECTURE.md.
- **CLAUDE.md**: Short subsection on ModelContext access and link to ARCHITECTURE.md.
- **docs/issues/ISSUE_VALIDATION_013.md**: Acceptance criteria mapping and QA checklist.
- **SpellPlayTests/ModelContextAccessTests.swift**: Unit test `inMemoryContainer_canInjectForTests` — in-memory `ModelContainer` and context passed to `AchievementService`; no logic change in app code.

## How to validate
- Build: `xcodebuild -project SpellPlay.xcodeproj -scheme SpellPlay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build`
- Unit tests: SpellPlayTests build with the project; run SpellPlayTests target in Xcode (⌘U) or via test bundle.
- Manual: Create test, practice, complete; confirm data and achievements/streaks unchanged.

Implements #26

Fixes #26

Made with [Cursor](https://cursor.com)
