### PR TITLE
Fix: SpellPlayUITests stability (onboarding / launch-argument reset)

### DIFF
--- a/SpellPlay/Components/OnboardingView.swift
+++ b/SpellPlay/Components/OnboardingView.swift
@@ -17,7 +17,8 @@ struct OnboardingView: View {
                 .font(.title.bold())
                 .foregroundColor(role == .parent ? AppConstants.primaryColor : AppConstants.secondaryColor)
                 .accessibilityAddTraits(.isHeader)
-                .accessibilityIdentifier(role == .parent ? "Onboarding_ParentModeTitle" : "Onboarding_PracticeModeTitle")
+                .accessibilityIdentifier(role == .parent ? "Onboarding_ParentModeTitle" :
+                    "Onboarding_PracticeModeTitle")
 
             VStack(alignment: .leading, spacing: 16) {
                 if role == .parent {

--- a/SpellPlay/Features/Child/Games/Common/GameResultService.swift
+++ b/SpellPlay/Features/Child/Games/Common/GameResultService.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// Default implementation of GameResultServiceProtocol for use by GameStateManager.
-/// Use this when creating GameStateManager in game views (e.g. GameStateManager(resultService: DefaultGameResultService.shared)).
+/// Use this when creating GameStateManager in game views (e.g. GameStateManager(resultService:
+/// DefaultGameResultService.shared)).
 final class DefaultGameResultService: GameResultServiceProtocol {
     static let shared = DefaultGameResultService()
 

--- a/SpellPlayUITests/AccessibilityTests.swift
+++ b/SpellPlayUITests/AccessibilityTests.swift
@@ -8,7 +8,7 @@ final class AccessibilityTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["-UITestingReset"]
+        app.launchArguments = ["UI_TESTING_RESET_STATE"]
         app.launch()
     }
 
@@ -147,9 +147,9 @@ final class AccessibilityTests: XCTestCase {
         // Step 2: Switch to child mode
         switchToChildMode()
 
-        // Step 3: Tap the test card to open Word Review
-        let testCard = app.buttons["ChildTestCard_UI Test Words"].firstMatch
-        XCTAssertTrue(testCard.waitForExistence(timeout: 5), "Child test card should exist")
+        // Step 3: Tap the test card to open Word Review (child cards use Button with TestCard_ identifier)
+        let testCard = app.buttons["TestCard_UI Test Words"].firstMatch
+        XCTAssertTrue(testCard.waitForExistence(timeout: 5), "Test card should exist on child home")
         testCard.tap()
 
         // Step 4: Start practice from Word Review

--- a/SpellPlayUITests/EdgeCaseTests.swift
+++ b/SpellPlayUITests/EdgeCaseTests.swift
@@ -102,13 +102,16 @@ final class EdgeCaseTests: XCTestCase {
 
         _ = TestHelpers.createTestViaUI(app, name: "Persistence Test", words: ["cat", "dog"])
 
-        // Restart app
+        // Restart app (launch args still include UI_TESTING_RESET_STATE so we see role selection again)
         app.terminate()
         app.launch()
         sleep(2)
 
-        // Test should still exist
-        let parentHomePage2 = ParentHomePage(app: app)
+        // Navigate back to parent home so we can verify the test list
+        let roleSelectionPage2 = RoleSelectionPage(app: app)
+        let onboardingPage2 = roleSelectionPage2.tapParentButton()
+        let parentHomePage2 = onboardingPage2.dismissAsParent()
+
         XCTAssertTrue(
             parentHomePage2.verifyTestExists(named: "Persistence Test"),
             "Test should persist after app restart")

--- a/SpellPlayUITests/PageObjects/BasePage.swift
+++ b/SpellPlayUITests/PageObjects/BasePage.swift
@@ -33,6 +33,13 @@ class BasePage {
         element.exists && element.isHittable
     }
 
+    /// Find element by accessibility identifier (any type). Use when the same ID is used on different element kinds
+    /// (e.g. TestCard_ on parent = container, on child = button).
+    func element(matchingIdentifier identifier: String) -> XCUIElement {
+        let predicate = NSPredicate(format: "identifier == %@", identifier)
+        return app.descendants(matching: .any).matching(predicate).firstMatch
+    }
+
     /// Scroll to element if needed
     func scrollToElement(_ element: XCUIElement) {
         if !element.isHittable {

--- a/SpellPlayUITests/PageObjects/ChildHomePage.swift
+++ b/SpellPlayUITests/PageObjects/ChildHomePage.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import XCTest
 
 class ChildHomePage: BasePage {
@@ -28,10 +29,17 @@ class ChildHomePage: BasePage {
     // MARK: - Action Methods
 
     func tapTestCard(named name: String) -> PracticePage {
-        let card = app.otherElements["TestCard_\(name)"]
-        waitForElement(card)
-        card.tap()
-        sleep(1) // Wait for navigation
+        // Child home uses Button for test cards
+        let card = app.buttons["TestCard_\(name)"]
+        _ = waitForElement(card, timeout: 10.0)
+        if !card.isHittable { app.swipeUp() }
+        // Use coordinate tap so the sheet opens reliably (avoids hit point -1,-1 in scroll views)
+        card.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        sleep(2) // Allow Word Review sheet to present
+        let startButton = app.buttons["WordReview_StartButton"]
+        _ = waitForElement(startButton, timeout: 10.0)
+        startButton.tap()
+        sleep(1) // Wait for Practice screen
         return PracticePage(app: app)
     }
 
@@ -44,12 +52,12 @@ class ChildHomePage: BasePage {
     // MARK: - Verification Methods
 
     func verifyTestExists(named name: String) -> Bool {
-        let card = app.otherElements["TestCard_\(name)"]
-        return waitForElement(card)
+        let card = element(matchingIdentifier: "TestCard_\(name)")
+        return waitForElement(card, timeout: 10.0)
     }
 
     func verifyEmptyState() -> Bool {
-        waitForElement(emptyStateText)
+        waitForElement(emptyStateText, timeout: 10.0)
     }
 
     func verifyStreakDisplayed(_ streak: Int) -> Bool {

--- a/SpellPlayUITests/PageObjects/ParentHomePage.swift
+++ b/SpellPlayUITests/PageObjects/ParentHomePage.swift
@@ -43,15 +43,15 @@ class ParentHomePage: BasePage {
     }
 
     func tapTestCard(named name: String) -> EditTestPage {
-        let card = app.otherElements["TestCard_\(name)"]
-        waitForElement(card)
+        let card = element(matchingIdentifier: "TestCard_\(name)")
+        _ = waitForElement(card, timeout: 10.0)
         card.tap()
         return EditTestPage(app: app)
     }
 
     func deleteTest(named name: String) -> Self {
-        let card = app.otherElements["TestCard_\(name)"]
-        if card.exists {
+        let card = element(matchingIdentifier: "TestCard_\(name)")
+        if card.waitForExistence(timeout: 5) {
             // Swipe to delete or tap delete button
             card.swipeLeft()
             let deleteButton = app.buttons["Delete"]
@@ -71,12 +71,12 @@ class ParentHomePage: BasePage {
     // MARK: - Verification Methods
 
     func verifyTestExists(named name: String) -> Bool {
-        let card = app.otherElements["TestCard_\(name)"]
-        return waitForElement(card)
+        let card = element(matchingIdentifier: "TestCard_\(name)")
+        return waitForElement(card, timeout: 10.0)
     }
 
     func verifyEmptyState() -> Bool {
-        waitForElement(emptyStateText)
+        waitForElement(emptyStateText, timeout: 10.0)
     }
 
     // MARK: - Query Methods

--- a/SpellPlayUITests/PageObjects/RoleSelectionPage.swift
+++ b/SpellPlayUITests/PageObjects/RoleSelectionPage.swift
@@ -24,13 +24,13 @@ class RoleSelectionPage: BasePage {
     // MARK: - Action Methods
 
     func tapParentButton() -> OnboardingPage {
-        waitForElement(parentButton)
+        _ = waitForElement(parentButton, timeout: 10.0)
         parentButton.tap()
         return OnboardingPage(app: app)
     }
 
     func tapChildButton() -> OnboardingPage {
-        waitForElement(childButton)
+        _ = waitForElement(childButton, timeout: 10.0)
         childButton.tap()
         return OnboardingPage(app: app)
     }

--- a/SpellPlayUITests/PageObjects/RoleSwitcherPage.swift
+++ b/SpellPlayUITests/PageObjects/RoleSwitcherPage.swift
@@ -12,7 +12,7 @@ class RoleSwitcherPage: BasePage {
     }
 
     var doneButton: XCUIElement {
-        app.buttons["Done"]
+        app.buttons["RoleSwitcher_DoneButton"]
     }
 
     // MARK: - Initializer

--- a/SpellPlayUITests/RoleSelectionTests.swift
+++ b/SpellPlayUITests/RoleSelectionTests.swift
@@ -47,7 +47,8 @@ final class RoleSelectionTests: XCTestCase {
         let onboardingPage = roleSelectionPage.tapParentButton()
         let parentHomePage = onboardingPage.dismissAsParent()
 
-        // Relaunch app - onboarding should not appear again
+        // Relaunch app - onboarding should not appear again (no reset so state is preserved)
+        app.launchArguments = []
         app.terminate()
         app.launch()
         sleep(2)
@@ -63,7 +64,8 @@ final class RoleSelectionTests: XCTestCase {
         let onboardingPage = roleSelectionPage.tapChildButton()
         let childHomePage = onboardingPage.dismissAsChild()
 
-        // Relaunch app - onboarding should not appear again
+        // Relaunch app - onboarding should not appear again (no reset so state is preserved)
+        app.launchArguments = []
         app.terminate()
         app.launch()
         sleep(2)


### PR DESCRIPTION
Implements #45. App clears role/onboarding in UserDefaults when launched with UI_TESTING_RESET_STATE; UI tests set that launch argument. Page object and identifier fixes for Parent/Child flows. Closes #45

Made with [Cursor](https://cursor.com)